### PR TITLE
Concurrency fix

### DIFF
--- a/api/internal/services/balance/service.go
+++ b/api/internal/services/balance/service.go
@@ -37,7 +37,7 @@ func InsertTransaction(clientId int, transaction model.Transaction) (model.Clien
 
 	if err != nil || err == sql.ErrNoRows {
 		log.Println(err)
-		return client, exception.UnprocessableEntity{
+		return client, exception.TransactionError{
 			Message: "Internal Server Error",
 		}
 
@@ -49,7 +49,7 @@ func InsertTransaction(clientId int, transaction model.Transaction) (model.Clien
 		newBalance = -transaction.Value
 	}
 
-	if client.Balance-transaction.Value < client.BalanceLimit*-1 {
+	if transaction.Type == "d" && client.Balance-transaction.Value < client.BalanceLimit*-1 {
 		return client, exception.UnprocessableEntity{
 			Message: "You have no limit for this transaction",
 		}

--- a/api/internal/services/balance/service.go
+++ b/api/internal/services/balance/service.go
@@ -20,7 +20,7 @@ func InsertTransaction(clientId int, transaction model.Transaction) (model.Clien
 	if err != nil {
 		log.Println("error on begin transaction clientID: " + fmt.Sprintf("%d", clientId))
 		return client, exception.TransactionError{
-			Message: "Error begin transaction",
+			Message: "Error on begin transaction",
 		}
 	}
 
@@ -28,35 +28,30 @@ func InsertTransaction(clientId int, transaction model.Transaction) (model.Clien
 
 	// usando o id como chave para bloqueio
 	// será liberado no commit ou no rollback
-	clientRow := sqlTransaction.QueryRow(`SELECT id, balanceLimit, balance FROM client WHERE id=$1 FOR UPDATE`, clientId)
+
+	sqlTransaction.Exec("SELECT pg_advisory_xact_lock($1)", clientId)
+
+	clientRow := sqlTransaction.QueryRow(`SELECT id, balanceLimit, balance FROM client WHERE id=$1`, clientId)
 
 	err = clientRow.Scan(&client.Id, &client.BalanceLimit, &client.Balance)
 
 	if err != nil || err == sql.ErrNoRows {
-
-		return client, exception.UserNotFound{
-			Message: "User not found",
+		log.Println(err)
+		return client, exception.UnprocessableEntity{
+			Message: "Internal Server Error",
 		}
 
 	}
 
-	newBalance := 0
+	newBalance := transaction.Value
+
 	if transaction.Type == "d" {
+		newBalance = -transaction.Value
+	}
 
-		newBalance := client.Balance - transaction.Value
-
-		if newBalance < (client.BalanceLimit * -1) {
-			return client, exception.UnprocessableEntity{
-				Message: "Value not accepted for 'd'",
-			}
-		}
-
-	} else {
-		newBalance = client.Balance + transaction.Value
-		if newBalance > client.BalanceLimit {
-			return client, exception.UnprocessableEntity{
-				Message: "Value not accepted for 'c'",
-			}
+	if client.Balance-transaction.Value < client.BalanceLimit*-1 {
+		return client, exception.UnprocessableEntity{
+			Message: "You have no limit for this transaction",
 		}
 	}
 
@@ -71,7 +66,7 @@ func InsertTransaction(clientId int, transaction model.Transaction) (model.Clien
 		}
 	}
 
-	updateRow := sqlTransaction.QueryRow(`UPDATE client SET balance=$1 WHERE id=$2 RETURNING balance`, newBalance, client.Id)
+	updateRow := sqlTransaction.QueryRow(`UPDATE client SET balance=balance + $1 WHERE id=$2 RETURNING balance`, newBalance, client.Id)
 
 	err = updateRow.Scan(&client.Balance)
 
@@ -96,11 +91,22 @@ func InsertTransaction(clientId int, transaction model.Transaction) (model.Clien
 func GetExtractByUserId(clientId int) (model.Extract, interface{}) {
 	conn := database.GetConnection()
 
-	sqlResult := conn.QueryRow(`SELECT id, balanceLimit, balance FROM client WHERE id=$1`, clientId)
+	sqlTransaction, err := conn.Begin() // TODO  tratar o erro na abertura da transaction
+
+	if err != nil {
+		log.Println("Error on begin transaction (Statement) clientID: " + fmt.Sprintf("%d", clientId))
+		return model.Extract{}, exception.TransactionError{
+			Message: "Error on begin transaction",
+		}
+	}
+
+	defer sqlTransaction.Rollback() // Se a transação não for commitada, ocorre o rollback
+
+	sqlResult := sqlTransaction.QueryRow(`SELECT id, balanceLimit, balance FROM client WHERE id=$1`, clientId)
 
 	client := model.Client{}
 
-	err := sqlResult.Scan(&client.Id, &client.BalanceLimit, &client.Balance)
+	err = sqlResult.Scan(&client.Id, &client.BalanceLimit, &client.Balance)
 
 	if err != nil && err == sql.ErrNoRows {
 		return model.Extract{}, exception.UserNotFound{
@@ -109,7 +115,7 @@ func GetExtractByUserId(clientId int) (model.Extract, interface{}) {
 
 	}
 
-	transactionRows, err := conn.Query(`
+	transactionRows, err := sqlTransaction.Query(`
 	SELECT t.value, t.type, t.description, t.date 
 	FROM transaction t WHERE t.client_id = $1 
 	ORDER BY t.date DESC LIMIT 10;`, clientId)
@@ -138,6 +144,15 @@ func GetExtractByUserId(clientId int) (model.Extract, interface{}) {
 		}
 
 		transactions = append(transactions, transaction)
+	}
+
+	err = sqlTransaction.Commit()
+
+	if err != nil {
+		log.Println("error on commit transaction (statement) clientID: " + fmt.Sprintf("%d", clientId))
+		return model.Extract{}, exception.TransactionError{
+			Message: "Error on commit message",
+		}
 	}
 
 	return model.Extract{

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       environment:
         - POSTGRES_PASSWORD=admin123
         - POSTGRES_USER=admin
-        - POSTGRES_DB=financeiro
+        - POSTGRES_DB=financial
       ports:
         - "5432:5432"
       volumes:

--- a/docker/initDB.sql
+++ b/docker/initDB.sql
@@ -1,6 +1,5 @@
-CREATE DATABASE financial;
-
 \c financial;
+
 
 CREATE TABLE IF NOT EXISTS client (
   id SERIAL PRIMARY KEY,
@@ -18,10 +17,9 @@ CREATE TABLE IF NOT EXISTS transaction (
   FOREIGN KEY (client_id) REFERENCES client(id)
 );
 
-
-INSERT (balanceLimit, balance) INTO client VALUES 
+INSERT INTO client(balanceLimit, balance) VALUES 
 (100000, 0), 
 (80000, 0), 
-(1000000, 0)), 
+(1000000, 0), 
 (10000000	, 0), 
 (500000, 0); 


### PR DESCRIPTION
### Porque tava dando o erro: 
Então, basicamente o que estava acontecendo é que você tava SETANDO o saldo baseado na primeira query que você fazia pra pegar o saldo do cliente, mas isso causa um problema de concorrência, então o que devemos fazer é SOMAR o saldo do cliente que JÁ está na tabela juntamente de um lock pessimista    
```sql
balance=balance+1    
em vez de   
balance=client.balance + 1
```
Eu não sei se deu pra entender, e eu tb não sei explicar direito, mas confia que funciona. 
Da uma olhada no commit "fix: concurrency" e lá da pra entender melhor

### O que foi feito
- Atualizei o docker-compose e o initDB.sql pra ficar mais semântico, e tava com um errinho também no initDB
- Resolvi o problema de concorrência e adicionei um lock pessimista
- Tirei uma validação de crédito que era desnecessária, já que a rinha só pede validação de débito, mas se você quiser pode adicionar de volta.